### PR TITLE
plcli: utils for key generation and support for publishing genesis ops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ test-coverage.out
 !.gitignore
 !.github/
 !.golangci.yaml
+
+plcli

--- a/client.go
+++ b/client.go
@@ -16,7 +16,7 @@ import (
 // the zero-value of this client is fully functional
 type Client struct {
 	DirectoryURL string
-	UserAgent    *string
+	UserAgent    string
 	HTTPClient   http.Client
 	RotationKey  *crypto.PrivateKey
 }
@@ -41,8 +41,8 @@ func (c *Client) Resolve(ctx context.Context, did string) (*Doc, error) {
 	if err != nil {
 		return nil, err
 	}
-	if c.UserAgent != nil {
-		req.Header.Set("User-Agent", *c.UserAgent)
+	if c.UserAgent != "" {
+		req.Header.Set("User-Agent", c.UserAgent)
 	} else {
 		req.Header.Set("User-Agent", "go-did-method-plc")
 	}
@@ -88,8 +88,8 @@ func (c *Client) Submit(ctx context.Context, did string, op Operation) error {
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	if c.UserAgent != nil {
-		req.Header.Set("User-Agent", *c.UserAgent)
+	if c.UserAgent != "" {
+		req.Header.Set("User-Agent", c.UserAgent)
 	} else {
 		req.Header.Set("User-Agent", "go-did-method-plc")
 	}
@@ -134,8 +134,8 @@ func (c *Client) OpLog(ctx context.Context, did string, audit bool) ([]LogEntry,
 	if err != nil {
 		return nil, err
 	}
-	if c.UserAgent != nil {
-		req.Header.Set("User-Agent", *c.UserAgent)
+	if c.UserAgent != "" {
+		req.Header.Set("User-Agent", c.UserAgent)
 	} else {
 		req.Header.Set("User-Agent", "go-did-method-plc")
 	}

--- a/client.go
+++ b/client.go
@@ -102,7 +102,15 @@ func (c *Client) Submit(ctx context.Context, did string, op Operation) error {
 		return ErrDIDNotFound
 	}
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("failed did:plc operation submission, HTTP status: %d", resp.StatusCode)
+		var body_str string
+		body := new(strings.Builder)
+		_, err := io.Copy(body, resp.Body)
+		if err != nil {
+			body_str = "<failed to read response body>"
+		} else {
+			body_str = body.String()
+		}
+		return fmt.Errorf("failed did:plc operation submission, HTTP status: %d\n%s", resp.StatusCode, body_str)
 	}
 
 	return nil

--- a/cmd/plcli/main.go
+++ b/cmd/plcli/main.go
@@ -15,6 +15,8 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+const PLCLI_USER_AGENT = "go-didplc/plcli"
+
 func main() {
 	app := cli.App{
 		Name:  "plcli",
@@ -111,6 +113,7 @@ func runResolve(cctx *cli.Context) error {
 
 	c := didplc.Client{
 		DirectoryURL: cctx.String("plc-host"),
+		UserAgent:    PLCLI_USER_AGENT,
 	}
 	doc, err := c.Resolve(ctx, did.String())
 	if err != nil {
@@ -129,6 +132,7 @@ func runSubmit(cctx *cli.Context) error {
 
 	c := didplc.Client{
 		DirectoryURL: cctx.String("plc-host"),
+		UserAgent:    PLCLI_USER_AGENT,
 	}
 
 	inBytes, err := io.ReadAll(os.Stdin)
@@ -203,6 +207,7 @@ func fetchOplog(cctx *cli.Context) ([]didplc.LogEntry, error) {
 
 	c := didplc.Client{
 		DirectoryURL: cctx.String("plc-host"),
+		UserAgent:    PLCLI_USER_AGENT,
 	}
 	entries, err := c.OpLog(ctx, did.String(), cctx.Bool("audit"))
 	if err != nil {

--- a/cmd/plcli/main.go
+++ b/cmd/plcli/main.go
@@ -180,15 +180,12 @@ func runSubmit(cctx *cli.Context) error {
 		}
 	}
 
-	entry, err := c.Submit(ctx, did_string, op)
+	err = c.Submit(ctx, did_string, op)
 	if err != nil {
 		return err
 	}
-	jsonBytes, err := json.Marshal(&entry)
-	if err != nil {
-		return err
-	}
-	fmt.Println(string(jsonBytes))
+
+	fmt.Printf("Successfully submited operation: %s/%s\n", c.DirectoryURL, did_string)
 	return nil
 }
 

--- a/cmd/plcli/main.go
+++ b/cmd/plcli/main.go
@@ -184,8 +184,7 @@ func runSubmit(cctx *cli.Context) error {
 		}
 	}
 
-	err = c.Submit(ctx, did_string, op)
-	if err != nil {
+	if err := c.Submit(ctx, did_string, op); err != nil {
 		return err
 	}
 

--- a/cmd/plcli/main.go
+++ b/cmd/plcli/main.go
@@ -142,7 +142,7 @@ func runSubmit(cctx *cli.Context) error {
 	op := enum.AsOperation()
 
 	s := cctx.Args().First()
-	var did_string string = ""
+	var did_string string
 	if s == "" {
 		if !op.IsGenesis() {
 			fmt.Println("a DID must be provided as argument for non-genesis ops")


### PR DESCRIPTION
Adds `keygen`, `derive_pubkey` commands, fixes the `submit` command, and lets it work for genesis ops too (computing the DID automatically)

Also, plcli now sets its own user-agent string, different to the client library's default.