### PR TITLE
Fix `oplog`, misc refactors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,4 @@ test-coverage.out
 !.github/
 !.golangci.yaml
 
-plcli
+/plcli

--- a/client.go
+++ b/client.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"strings"
 
@@ -33,15 +33,13 @@ func processErrorResponse(resp *http.Response, msg string) error {
 		return ErrDIDNotFound
 	}
 
-	var body_str string
 	body := new(strings.Builder)
 	_, err := io.Copy(body, resp.Body)
 	if err != nil {
-		body_str = "<failed to read response body>"
+		slog.Info("failed reading PLC directory response body", "status_code", resp.StatusCode)
 	} else {
-		body_str = body.String()
+		slog.Info("PLC directory request failed", "status_code", resp.StatusCode, "body", body.String())
 	}
-	log.Println(body_str) // TODO: configure logging better
 
 	return fmt.Errorf("%s, HTTP status: %d", msg, resp.StatusCode)
 }

--- a/cmd/plcli/main.go
+++ b/cmd/plcli/main.go
@@ -94,7 +94,7 @@ func main() {
 	}
 	h := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug})
 	slog.SetDefault(slog.New(h))
-	app.Run(os.Args)
+	app.RunAndExitOnError()
 }
 
 func runResolve(cctx *cli.Context) error {

--- a/cmd/plcli/main.go
+++ b/cmd/plcli/main.go
@@ -119,7 +119,7 @@ func runResolve(cctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	jsonBytes, err := json.Marshal(&doc)
+	jsonBytes, err := json.MarshalIndent(&doc, "", "  ")
 	if err != nil {
 		return err
 	}
@@ -221,7 +221,7 @@ func runOpLog(cctx *cli.Context) error {
 		return err
 	}
 
-	jsonBytes, err := json.Marshal(&entries)
+	jsonBytes, err := json.MarshalIndent(&entries, "", "  ")
 	if err != nil {
 		return err
 	}
@@ -258,7 +258,7 @@ func runAuditLog(cctx *cli.Context) error {
 		return err
 	}
 
-	jsonBytes, err := json.Marshal(&entries)
+	jsonBytes, err := json.MarshalIndent(&entries, "", "  ")
 	if err != nil {
 		return err
 	}

--- a/cmd/plcli/main.go
+++ b/cmd/plcli/main.go
@@ -31,13 +31,13 @@ func main() {
 		},
 	}
 	app.Commands = []*cli.Command{
-		&cli.Command{
+		{
 			Name:      "resolve",
 			Usage:     "resolve a DID from remote PLC directory",
 			ArgsUsage: "<did>",
 			Action:    runResolve,
 		},
-		&cli.Command{
+		{
 			Name:      "submit",
 			Usage:     "submit a PLC operation (reads JSON from stdin)",
 			ArgsUsage: "<did>",
@@ -50,19 +50,19 @@ func main() {
 				},
 			},
 		},
-		&cli.Command{
+		{
 			Name:      "oplog",
 			Usage:     "fetch log of operations from PLC directory, for a single DID",
 			ArgsUsage: "<did>",
 			Action:    runOpLog,
 		},
-		&cli.Command{
+		{
 			Name:      "auditlog",
 			Usage:     "fetch audit log of operations from PLC directory, for a single DID (includes nullified ops, timestamps)",
 			ArgsUsage: "<did>",
 			Action:    runAuditLog,
 		},
-		&cli.Command{
+		{
 			Name:      "verify",
 			Usage:     "fetch audit log for a DID, and verify all operations",
 			ArgsUsage: "<did>",
@@ -74,12 +74,12 @@ func main() {
 				},
 			},
 		},
-		&cli.Command{
+		{
 			Name:   "keygen",
 			Usage:  "generate a fresh k256 private key, printed to stdout as a multibase string",
 			Action: runKeyGen,
 		},
-		&cli.Command{
+		{
 			Name:   "derive_pubkey",
 			Usage:  "derive a public key and print to stdout in did:key format",
 			Action: runDerivePubkey,
@@ -94,7 +94,7 @@ func main() {
 	}
 	h := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug})
 	slog.SetDefault(slog.New(h))
-	app.RunAndExitOnError()
+	app.Run(os.Args)
 }
 
 func runResolve(cctx *cli.Context) error {

--- a/diddoc.go
+++ b/diddoc.go
@@ -1,7 +1,5 @@
 package didplc
 
-import ()
-
 type DocVerificationMethod struct {
 	ID                 string `json:"id"`
 	Type               string `json:"type"`
@@ -17,7 +15,7 @@ type DocService struct {
 
 type Doc struct {
 	ID                 string                  `json:"id"`
-	AlsoKnownAs        []string                `json:"alsoKnownAs,omitempty"`
-	VerificationMethod []DocVerificationMethod `json:"verificationMethod,omitempty"`
-	Service            []DocService            `json:"service,omitempty"`
+	AlsoKnownAs        []string                `json:"alsoKnownAs"`
+	VerificationMethod []DocVerificationMethod `json:"verificationMethod"`
+	Service            []DocService            `json:"service"`
 }


### PR DESCRIPTION
I fixed the `oplog` command (which was previously broken - the response schema for `/log` is different to that of `/log/audit`) and split out `auditlog` as a separate command that does what `oplog --audit` used to do.

I did some misc refactoring to support this, improved HTTP error response logging, and added pretty-printing for JSON outputs (i.e. `json.MarshalIndent`)