### PR TITLE
nontriv nulli test: put non-clobbered ops >72h

### DIFF
--- a/testdata/README.md
+++ b/testdata/README.md
@@ -16,7 +16,7 @@ These lists do *not* presently include operations/DIDs containing duplicate rota
               '-------<------------------<----'
 ```
 
-(all within 72h)
+(op2 follows op1 by more than 72h, ops3–7 all within 72h of op2)
 
 After operation 6, only op 4 would be nullified. After operation 7, all operations 2-6 will be nullified.
 

--- a/testdata/log_nullification_nontrivial.json
+++ b/testdata/log_nullification_nontrivial.json
@@ -17,7 +17,7 @@
     },
     "cid": "bafyreiadih3ot3zecxp3yghygj2mwxh3szrrifwer2z4iodazbrtuvmmgm",
     "nullified": false,
-    "createdAt": "2025-07-25T14:14:48.962Z"
+    "createdAt": "2025-07-01T00:00:00.000Z"
   },
   {
     "did": "did:plc:ana7n2ppeqk57pay7azhjs24",
@@ -37,7 +37,7 @@
     },
     "cid": "bafyreieshd5ujokbnxfzqmaoyimbdsiuwklji2st7ffga2vkhsozxn324u",
     "nullified": false,
-    "createdAt": "2025-07-25T14:14:49.353Z"
+    "createdAt": "2025-07-1T00:00:01.000Z"
   },
   {
     "did": "did:plc:ana7n2ppeqk57pay7azhjs24",


### PR DESCRIPTION
the sequence of ops used by `log_nullification_nontrivial.json`,

```
(op0)<-(op1)<-(op2)<-(op3)<-(op4)  (op5)<-(op6)  (op7)
            \             \       /             /
             \             '--<--'             /
              '-------<------------------<----'
```

has *all* ops happening within 72h, but it seems clear that

- op0 can be arbitrarily earlier, and
- op1 can maybe also be arbirarily earlier? (at least that's what i'd expect)

this change moves op0 and op1 outside the 72h window, so that only *clobbered* events are inside it

the [wording in the spec](https://github.com/did-method-plc/did-method-plc?tab=readme-ov-file#key-rotation--account-recovery) about the conditions for clobbering ops was slightly unclear to me, so i tried to dig into test cases for certainty before suggesting a wording change, and ended up here. accepting or resolving this change (specifically re op1) would clarify my question about the spec.

---

note: i *expected* the test to fail when i moved `op2` outside the 72h window as well, but it did not. from what i can see, the tests only asserts that a sequence of events is made up of a valid submitted ops, but not that any are accepted/rejected or that any particular state results at the end. if that's not meant to be the case, i'd love to add assertions about that!