### PR TITLE
bump golang to v1.25

### DIFF
--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go tooling
         uses: actions/setup-go@v4
         with:
-          go-version: "1.24"
+          go-version: "1.25"
       - name: Build
         run: make build
       - name: Test
@@ -32,6 +32,6 @@ jobs:
       - name: Set up Go tooling
         uses: actions/setup-go@v4
         with:
-          go-version: "1.24"
+          go-version: "1.25"
       - name: Lint
         run: make lint

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/did-method-plc/go-didplc
 
-go 1.24
+go 1.25
 
-toolchain go1.24.1
+toolchain go1.25.1
 
 require (
 	github.com/bluesky-social/indigo v0.0.0-20251009212240-20524de167fe


### PR DESCRIPTION
This is part of our general Go update policy, which is to keep up with stable go releases once there have been a couple patch-level releases (which there have been for a while now with 1.25).

This doesn't get us `json/v2` (it's still behind an env var), but IMO we should keep up with aggressive updates until `json/v2` lands, maybe we can stabilize a bit more after that.